### PR TITLE
#39 Right align numbers

### DIFF
--- a/backend/pkg/reporter/reporter.go
+++ b/backend/pkg/reporter/reporter.go
@@ -119,7 +119,17 @@ func (r *Report) writeDate(sheetName string) error {
 }
 
 func (r *Report) writeCell(sheetName string, cellRef string, value interface{}) {
-	r.file.SetCellValue(sheetName, cellRef, value)
+	if _, ok := value.(string); ok {
+		r.file.SetCellValue(sheetName, cellRef, value)
+	} else if boolean, ok := value.(bool); ok {
+		r.file.SetCellBool(sheetName, cellRef, boolean)
+	} else {
+		if style, err := r.file.NewStyle(`{"number_format": 2}`); err == nil {
+			r.file.SetCellStyle(sheetName, cellRef, cellRef, style)
+		}
+		r.file.SetCellValue(sheetName, cellRef, value)
+	}
+
 }
 
 func (r *Report) SetSheets(panels []api.TablePanel) {


### PR DESCRIPTION
This will make numbers written as numbers (also maybe im missing some other data type which will be written with a number format?)

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/35858975/99894618-6bf32b80-2cea-11eb-8a76-f3a1c4d127a2.png">


But: This is removing the style of the cell and making it different from the row. PRing this as is because I'm unsure of a solution and looking for ideas.

You can get a ref to the style of the row (or specifically a cell in the row), but you can't get the actual attributes of the style in order to be able to create a new style with the `number_format` appended to it, so this just overwrites the whole style. Hm.


Also, there is also the header. Hmx2