### PR TITLE
select correct schedule when getting schedule

### DIFF
--- a/backend/pkg/dbstore/schedule.go
+++ b/backend/pkg/dbstore/schedule.go
@@ -217,7 +217,7 @@ func (datasource *SQLiteDatasource) GetSchedule(id string) (*Schedule, error) {
 
 	var schedules []Schedule
 
-	rows, err := db.Query("SELECT * FROM Schedule")
+	rows, err := db.Query("SELECT * FROM Schedule where id=?", id)
 	defer rows.Close()
 	if err != nil {
 		log.DefaultLogger.Error("GetSchedules: db.Query(): ", err.Error())


### PR DESCRIPTION
The `GetSchedule` method was always returning the first available schedule. 
I've limited to the specified id - which opens the possibility of tidying up the rest of the method.. but I haven't.