### PR TITLE
include old table type

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -180,7 +180,7 @@ export const getPanels = async (datasourceID: number): Promise<Panel[]> => {
     .filter(({ panels }) => panels?.length > 0)
     .map(({ panels, templating, uid }) => {
       const mappedPanels = panels
-        .filter(({ type }) => type === 'table')
+        .filter(({ type }) => type === 'table' || type === 'table-old')
         .map(rawPanel => {
           const { targets } = rawPanel;
           const [target] = targets;


### PR DESCRIPTION
Fixes #46 

If the dashboard was created while v6 was installed, then the plugin used is the old, angular version of the plugin. On upgrading to v7 the plugin used is an interim 'table-old' plugin, and the user has to manually switch over to the new table plugin ( there are differences which need accounting for.. )

Long story short.. have added support for the old table plugin.