### PR TITLE
export & download

### DIFF
--- a/backend/pkg/api/dashboard.go
+++ b/backend/pkg/api/dashboard.go
@@ -162,7 +162,7 @@ func NewDashboard(authConfig *auth.AuthConfig, uuid string, from string, to stri
 	url := authConfig.AuthURL() + "/api/dashboards/uid/" + uuid
 	response, err := http.Get(url)
 	if err != nil {
-		log.DefaultLogger.Error("NewDashboard: HTTP Request", err.Error())
+		log.DefaultLogger.Error("NewDashboard: HTTP Request %s", err.Error())
 		return nil, err
 	}
 
@@ -174,7 +174,7 @@ func NewDashboard(authConfig *auth.AuthConfig, uuid string, from string, to stri
 
 	var panels []TablePanel
 	for _, panel := range dashboardResponse.Dashboard.Panels {
-		if panel.Type == "table" {
+		if panel.Type == "table" || panel.Type == "msupply-table" {
 			newPanel := NewTablePanel(panel.ID, panel.Title, panel.Targets[0].RawSQL, from, to, datasourceID)
 			panels = append(panels, *newPanel)
 		}

--- a/backend/pkg/api/panel.go
+++ b/backend/pkg/api/panel.go
@@ -180,3 +180,7 @@ func (panel *TablePanel) SetColumns(columns []Column) {
 func (panel *TablePanel) SetSql(query string) {
 	panel.RawSql = query
 }
+
+func (panel *TablePanel) SetTitle(title string) {
+	panel.Title = title
+}

--- a/backend/pkg/api/panel.go
+++ b/backend/pkg/api/panel.go
@@ -176,3 +176,7 @@ func (panel *TablePanel) SetRows(rows [][]interface{}) {
 func (panel *TablePanel) SetColumns(columns []Column) {
 	panel.Columns = columns
 }
+
+func (panel *TablePanel) SetSql(query string) {
+	panel.RawSql = query
+}

--- a/backend/pkg/reporter/reporter.go
+++ b/backend/pkg/reporter/reporter.go
@@ -357,6 +357,35 @@ func (r *Report) Write(auth auth.AuthConfig) error {
 	return nil
 }
 
+func (r *Reporter) ExportPanel(authConfig *auth.AuthConfig, datasourceID int, dashboardID string, panelID int, query string) (string, error) {
+
+	dashboard, err := api.NewDashboard(authConfig, dashboardID, "", "", datasourceID)
+	if err != nil {
+		log.DefaultLogger.Error("Reporter.ExportPanel: NewDashboard: " + err.Error())
+		return "", err
+	}
+
+	panel := dashboard.Panel(panelID)
+	if panel == nil {
+		log.DefaultLogger.Error("Reporter.ExportPanel: NewDashboard: panel is nil")
+		return "", errors.New(fmt.Sprintf("panel with ID %d cannot be found", panelID))
+	}
+
+	panel.SetSql(query)
+
+	reportSheetPanels := []api.TablePanel{*panel}
+	report := r.CreateNewReport(strconv.Itoa(panelID), panel.Title)
+	report.SetSheets(reportSheetPanels)
+
+	err = report.Write(*authConfig)
+	if err != nil {
+		log.DefaultLogger.Error("ReportEmailer.createReports: report.Write: " + err.Error())
+		return "", err
+	}
+
+	return panel.Title + ".xlsx", nil
+}
+
 func GetFilePath(fileName string) string {
 
 	filePath := filepath.Join("..", "data", fileName+".xlsx")

--- a/backend/pkg/reporter/reporter.go
+++ b/backend/pkg/reporter/reporter.go
@@ -357,7 +357,7 @@ func (r *Report) Write(auth auth.AuthConfig) error {
 	return nil
 }
 
-func (r *Reporter) ExportPanel(authConfig *auth.AuthConfig, datasourceID int, dashboardID string, panelID int, query string) (string, error) {
+func (r *Reporter) ExportPanel(authConfig *auth.AuthConfig, datasourceID int, dashboardID string, panelID int, query string, title string) (string, error) {
 
 	dashboard, err := api.NewDashboard(authConfig, dashboardID, "", "", datasourceID)
 	if err != nil {
@@ -372,6 +372,7 @@ func (r *Reporter) ExportPanel(authConfig *auth.AuthConfig, datasourceID int, da
 	}
 
 	panel.SetSql(query)
+	panel.SetTitle(title)
 
 	reportSheetPanels := []api.TablePanel{*panel}
 	report := r.CreateNewReport(strconv.Itoa(panelID), panel.Title)

--- a/backend/pkg/server/export_panel.go
+++ b/backend/pkg/server/export_panel.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/simple-datasource-backend/pkg/auth"
+	"github.com/grafana/simple-datasource-backend/pkg/reporter"
+)
+
+type ExportPanelArgs struct {
+	DashboardID string `json:"dashboardID"`
+	PanelID     int    `json:"panelID"`
+	Query       string `json:"query"`
+}
+
+func ExportPanelArgsFields() string {
+	return "\n{\n\tPanelID int\n\t" +
+		"DashboardID string\n\t" +
+		"Query string\n\t" +
+		"\n}"
+}
+
+func (server *HttpServer) exportPanel(rw http.ResponseWriter, request *http.Request) {
+	var args ExportPanelArgs
+
+	requestBody, err := request.GetBody()
+	if err != nil {
+		log.DefaultLogger.Error("exportPanel: request.GetBody(): " + err.Error())
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		panic(err)
+	}
+
+	bodyAsBytes, err := ioutil.ReadAll(requestBody)
+	if err != nil {
+		log.DefaultLogger.Error("exportPanel: ioutil.ReadAll(): " + err.Error())
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		panic(err)
+	}
+
+	err = json.Unmarshal(bodyAsBytes, &args)
+	if err != nil {
+		log.DefaultLogger.Error("exportPanel: json.Unmarshal: " + err.Error())
+		http.Error(rw, NewRequestBodyError(err, ExportPanelArgsFields()).Error(), http.StatusBadRequest)
+		panic(err)
+	}
+
+	authConfig, err := auth.NewAuthConfig(server.db)
+	if err != nil {
+		log.DefaultLogger.Error("exportPanel: auth.NewAuthConfig: ", err.Error())
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		panic(err)
+	}
+
+	settings, err := server.db.GetSettings()
+	if err != nil {
+		log.DefaultLogger.Error("exportPanel: db.GetSettings: ", err.Error())
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		panic(err)
+	}
+
+	templatePath := reporter.GetFilePath("template")
+	reporter := reporter.NewReporter(templatePath)
+
+	url, err := reporter.ExportPanel(authConfig, settings.DatasourceID, args.DashboardID, args.PanelID, args.Query)
+	if err != nil {
+		log.DefaultLogger.Error("exportPanel: reporter.SaveReport: ", err.Error())
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		panic(err)
+	}
+
+	fmt.Fprint(rw, url)
+	rw.WriteHeader(http.StatusOK)
+}

--- a/backend/pkg/server/export_panel.go
+++ b/backend/pkg/server/export_panel.go
@@ -15,12 +15,14 @@ type ExportPanelArgs struct {
 	DashboardID string `json:"dashboardID"`
 	PanelID     int    `json:"panelID"`
 	Query       string `json:"query"`
+	Title       string `json:"title"`
 }
 
 func ExportPanelArgsFields() string {
 	return "\n{\n\tPanelID int\n\t" +
 		"DashboardID string\n\t" +
 		"Query string\n\t" +
+		"Title string\n\t" +
 		"\n}"
 }
 
@@ -65,7 +67,7 @@ func (server *HttpServer) exportPanel(rw http.ResponseWriter, request *http.Requ
 	templatePath := reporter.GetFilePath("template")
 	reporter := reporter.NewReporter(templatePath)
 
-	url, err := reporter.ExportPanel(authConfig, settings.DatasourceID, args.DashboardID, args.PanelID, args.Query)
+	url, err := reporter.ExportPanel(authConfig, settings.DatasourceID, args.DashboardID, args.PanelID, args.Query, args.Title)
 	if err != nil {
 		log.DefaultLogger.Error("exportPanel: reporter.SaveReport: ", err.Error())
 		http.Error(rw, err.Error(), http.StatusBadRequest)

--- a/backend/pkg/server/server.go
+++ b/backend/pkg/server/server.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"net/http"
+
 	"github.com/bugsnag/bugsnag-go"
 	"github.com/gorilla/mux"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -43,6 +45,8 @@ func (server *HttpServer) ResourceHandler(sqliteDatasource *dbstore.SQLiteDataso
 	mux.HandleFunc("/report-content/{id}", bugsnag.HandlerFunc(server.deleteReportContent)).Methods("DELETE")
 
 	mux.HandleFunc("/test-email", bugsnag.HandlerFunc(server.testEmail)).Queries("schedule-id", "{schedule-id}").Methods("GET")
+	mux.HandleFunc("/export-panel", bugsnag.HandlerFunc(server.exportPanel)).Methods("POST")
+	mux.PathPrefix("/download/").Handler(http.StripPrefix("/download/", http.FileServer(http.Dir("../data")))).Methods("GET")
 
 	return httpadapter.New(mux)
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -180,7 +180,7 @@ export const getPanels = async (datasourceID: number): Promise<Panel[]> => {
     .filter(({ panels }) => panels?.length > 0)
     .map(({ panels, templating, uid }) => {
       const mappedPanels = panels
-        .filter(({ type }) => type === 'table' || type === 'table-old')
+        .filter(({ type }) => type === 'table' || type === 'table-old' || type === 'msupply-table')
         .map(rawPanel => {
           const { targets } = rawPanel;
           const [target] = targets;


### PR DESCRIPTION
fixes #56 

Adds support to generate an excel spreadsheet for a specific panel, by providing the rawSQL used.
Allows a front-end client to download the spreadsheet