### PR TITLE
#115 Schedular: Schedular report sending same reports multiple time

### DIFF
--- a/pkg/datasource/schedule.go
+++ b/pkg/datasource/schedule.go
@@ -147,7 +147,7 @@ func (datasource *MsupplyEresDatasource) UpdateSchedule(id string, status string
 	db, err := sql.Open("sqlite", datasource.DataPath)
 	defer db.Close()
 	if err != nil {
-		log.DefaultLogger.Error("UpdateSchedule: sql.Open()", err.Error())
+		log.DefaultLogger.Error(": sql.Open()", err.Error())
 		return nil, err
 	}
 
@@ -158,7 +158,8 @@ func (datasource *MsupplyEresDatasource) UpdateSchedule(id string, status string
 	}
 
 	schedule.UpdateNextReportTime()
-	_, err = stmt.Exec(schedule.NextReportTime, schedule.Interval, schedule.Name, schedule.Description, schedule.Lookback, schedule.ReportGroupID, schedule.Time, schedule.Day, schedule.DateFormat, schedule.DatePosition, schedule.Status, id)
+
+	_, err = stmt.Exec(schedule.NextReportTime, schedule.Interval, schedule.Name, schedule.Description, schedule.Lookback, schedule.ReportGroupID, schedule.Time, schedule.Day, schedule.DateFormat, schedule.DatePosition, status, id)
 	defer stmt.Close()
 	if err != nil {
 		log.DefaultLogger.Error("UpdateSchedule: stmt.Exec()", err.Error())
@@ -177,12 +178,15 @@ func (datasource *MsupplyEresDatasource) UpdateScheduleProgess(id string, status
 	}
 
 	stmt, err := db.Prepare("UPDATE Schedule SET nextReportTime = ?, interval = ?, name = ?, description = ?, lookback = ?, reportGroupID = ?, time = ?, day = ?, dateFormat = ?, datePosition = ?, status = ? where id = ?")
+	log.DefaultLogger.Info("anil test executing update code for status",status)
+	log.DefaultLogger.Info("anil test executing update code for schedule",schedule)
+	
 	if err != nil {
 		log.DefaultLogger.Error("UpdateSchedule: db.Prepare()", err.Error())
 		return nil, err
 	}
 
-	_, err = stmt.Exec(schedule.NextReportTime, schedule.Interval, schedule.Name, schedule.Description, schedule.Lookback, schedule.ReportGroupID, schedule.Time, schedule.Day, schedule.DateFormat, schedule.DatePosition, schedule.Status, id)
+	_, err = stmt.Exec(schedule.NextReportTime, schedule.Interval, schedule.Name, schedule.Description, schedule.Lookback, schedule.ReportGroupID, schedule.Time, schedule.Day, schedule.DateFormat, schedule.DatePosition, status, id)
 	defer stmt.Close()
 	if err != nil {
 		log.DefaultLogger.Error("UpdateSchedule: stmt.Exec()", err.Error())

--- a/pkg/datasource/schedule_with_details.go
+++ b/pkg/datasource/schedule_with_details.go
@@ -55,7 +55,8 @@ func (datasource *MsupplyEresDatasource) CreateScheduleWithDetails(scheduleWithD
 		scheduleWithDetails.ID = uuid.New().String()
 
 		scheduleWithDetails.UpdateNextReportTime()
-
+		scheduleWithDetails.Status = "success"
+		
 		_, err = stmt.Exec(scheduleWithDetails.ID, scheduleWithDetails.NextReportTime, scheduleWithDetails.Interval, scheduleWithDetails.Name, scheduleWithDetails.Description, scheduleWithDetails.Lookback, scheduleWithDetails.ReportGroupID, scheduleWithDetails.Time, scheduleWithDetails.Day, scheduleWithDetails.DateFormat, scheduleWithDetails.DatePosition, scheduleWithDetails.Status)
 		if err != nil {
 			err = ereserror.New(500, errors.Wrap(err, frame.Function), "Could not create schedule record")

--- a/pkg/datasource/schedule_with_details.go
+++ b/pkg/datasource/schedule_with_details.go
@@ -23,6 +23,7 @@ type Schedule struct {
 	PanelDetails   []ReportContent `json:"panelDetails"`
 	DateFormat     string          `json:"dateFormat"`
 	DatePosition   string          `json:"datePosition"`
+	Status         string          `json:"status"`
 }
 
 type ReportContent struct {
@@ -44,7 +45,7 @@ func (datasource *MsupplyEresDatasource) CreateScheduleWithDetails(scheduleWithD
 	defer sqlClient.Db.Close()
 
 	if scheduleWithDetails.ID == "" {
-		stmt, err := sqlClient.Db.Prepare("INSERT INTO Schedule (id, nextReportTime, interval, name, description, lookback,reportGroupID,time,day,dateFormat, datePosition) VALUES (?,?,?,?,?,?,?,?,?,?,?) RETURNING *")
+		stmt, err := sqlClient.Db.Prepare("INSERT INTO Schedule (id, nextReportTime, interval, name, description, lookback,reportGroupID,time,day,dateFormat, datePosition, status) VALUES (?,?,?,?,?,?,?,?,?,?,?,?) RETURNING *")
 		if err != nil {
 			err = ereserror.New(500, errors.Wrap(err, frame.Function), "Could not create schedule record")
 			return nil, err
@@ -55,13 +56,13 @@ func (datasource *MsupplyEresDatasource) CreateScheduleWithDetails(scheduleWithD
 
 		scheduleWithDetails.UpdateNextReportTime()
 
-		_, err = stmt.Exec(scheduleWithDetails.ID, scheduleWithDetails.NextReportTime, scheduleWithDetails.Interval, scheduleWithDetails.Name, scheduleWithDetails.Description, scheduleWithDetails.Lookback, scheduleWithDetails.ReportGroupID, scheduleWithDetails.Time, scheduleWithDetails.Day, scheduleWithDetails.DateFormat, scheduleWithDetails.DatePosition)
+		_, err = stmt.Exec(scheduleWithDetails.ID, scheduleWithDetails.NextReportTime, scheduleWithDetails.Interval, scheduleWithDetails.Name, scheduleWithDetails.Description, scheduleWithDetails.Lookback, scheduleWithDetails.ReportGroupID, scheduleWithDetails.Time, scheduleWithDetails.Day, scheduleWithDetails.DateFormat, scheduleWithDetails.DatePosition, scheduleWithDetails.Status)
 		if err != nil {
 			err = ereserror.New(500, errors.Wrap(err, frame.Function), "Could not create schedule record")
 			return nil, err
 		}
 	} else {
-		stmt, err := sqlClient.Db.Prepare("UPDATE Schedule SET nextReportTime = ?, interval = ?, name = ?, description = ?, lookback = ?, reportGroupID = ?, time = ?, day = ?, dateFormat = ?, datePosition = ? where id = ? RETURNING *")
+		stmt, err := sqlClient.Db.Prepare("UPDATE Schedule SET nextReportTime = ?, interval = ?, name = ?, description = ?, lookback = ?, reportGroupID = ?, time = ?, day = ?, dateFormat = ?, datePosition = ?, status = ? where id = ? RETURNING *")
 		if err != nil {
 			err = ereserror.New(500, errors.Wrap(err, frame.Function), "Could not update schedule record")
 			return nil, err
@@ -70,7 +71,7 @@ func (datasource *MsupplyEresDatasource) CreateScheduleWithDetails(scheduleWithD
 
 		scheduleWithDetails.UpdateNextReportTime()
 
-		_, err = stmt.Exec(scheduleWithDetails.NextReportTime, scheduleWithDetails.Interval, scheduleWithDetails.Name, scheduleWithDetails.Description, scheduleWithDetails.Lookback, scheduleWithDetails.ReportGroupID, scheduleWithDetails.Time, scheduleWithDetails.Day, scheduleWithDetails.DateFormat, scheduleWithDetails.DatePosition, scheduleWithDetails.ID)
+		_, err = stmt.Exec(scheduleWithDetails.NextReportTime, scheduleWithDetails.Interval, scheduleWithDetails.Name, scheduleWithDetails.Description, scheduleWithDetails.Lookback, scheduleWithDetails.ReportGroupID, scheduleWithDetails.Time, scheduleWithDetails.Day, scheduleWithDetails.DateFormat, scheduleWithDetails.DatePosition, scheduleWithDetails.Status, scheduleWithDetails.ID)
 		if err != nil {
 			err = ereserror.New(500, errors.Wrap(err, frame.Function), "Could not update schedule record")
 			return nil, err

--- a/pkg/report-emailer/report_emailer.go
+++ b/pkg/report-emailer/report_emailer.go
@@ -68,6 +68,7 @@ func (re *ReportEmailer) cleanup(schedules []datasource.Schedule) {
 		}
 
 		schedule.UpdateNextReportTime()
+	    log.DefaultLogger.Info("anil test cleanup schedule id "+schedule.ID + "to status success")
 		re.datasource.UpdateSchedule(schedule.ID, "success", schedule)
 	}
 
@@ -215,6 +216,7 @@ func (re *ReportEmailer) CreateReports() {
 	panels := make(map[string][]api.TablePanel)
 	for _, schedule := range schedules {
 		reportGroup, err := re.datasource.ReportGroupFromSchedule(schedule)
+		log.DefaultLogger.Info("anil test updating schedule id "+schedule.ID + "to status progress")
 		re.datasource.UpdateScheduleProgess(schedule.ID, "progress", schedule)
 
 		if err != nil {

--- a/pkg/report-emailer/report_emailer.go
+++ b/pkg/report-emailer/report_emailer.go
@@ -24,7 +24,7 @@ func (re *ReportEmailer) Init() {
 
 	// Set up scheduler which will try to send reports every 10 minutes
 	c := cron.New()
-	c.AddFunc("@every 2m", func() {
+	c.AddFunc("@every 5m", func() {
 		re.CreateReports()
 	})
 
@@ -58,7 +58,8 @@ func (re *ReportEmailer) cleanup(schedules []datasource.Schedule) {
 	for _, schedule := range schedules {
 
 		log.DefaultLogger.Info(fmt.Sprintf("Deleting %s.xlsx...", schedule.Name))
-		path := GetFilePath(schedule.Name)
+		schedularFileName := GetFormattedFileName(schedule.Name, schedule.DateFormat, schedule.DatePosition)
+		path := GetFilePath(schedularFileName)
 		err := os.Remove(path)
 		if err != nil {
 			// Failure case shouldn't be much of a problem since we're using the schedule ID for the report name, at the moment
@@ -67,7 +68,7 @@ func (re *ReportEmailer) cleanup(schedules []datasource.Schedule) {
 		}
 
 		schedule.UpdateNextReportTime()
-		re.datasource.UpdateSchedule(schedule.ID, schedule)
+		re.datasource.UpdateSchedule(schedule.ID, "success", schedule)
 	}
 
 	re.inProgress = false
@@ -76,7 +77,6 @@ func (re *ReportEmailer) cleanup(schedules []datasource.Schedule) {
 func (re *ReportEmailer) CreateReport(schedule datasource.Schedule, authConfig *auth.AuthConfig, datasourceID int, em Emailer) error {
 
 	log.DefaultLogger.Debug("ReportEmailer.createReport: start")
-
 	emails := make(map[string][]string)
 	panels := make(map[string][]api.TablePanel)
 
@@ -215,6 +215,8 @@ func (re *ReportEmailer) CreateReports() {
 	panels := make(map[string][]api.TablePanel)
 	for _, schedule := range schedules {
 		reportGroup, err := re.datasource.ReportGroupFromSchedule(schedule)
+		re.datasource.UpdateScheduleProgess(schedule.ID, "progress", schedule)
+
 		if err != nil {
 			log.DefaultLogger.Error("ReportEmailer.createReports: ReportGroupFromSchedule: " + err.Error())
 			return


### PR DESCRIPTION
We are receiving the same reports many times when the report execution time is huge.
And report date and time stamp is updated only when the process are completed. Thus added a status field in database which we can update while working on that report as "progress" and success once the report is completed.