### PR TITLE
changing Datasource string to Datasource interface{}

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -48,8 +48,8 @@ type DashboardResponse struct {
 		Annotations struct {
 			List []struct {
 				BuiltIn    int    `json:"builtIn"`
-				Datasource string `json:"datasource"`
-				Enable     bool   `json:"enable"`
+				Datasource interface{} `json:"datasource"`
+				Enable     bool       `json:"enable"`
 				Hide       bool   `json:"hide"`
 				IconColor  string `json:"iconColor"`
 				Name       string `json:"name"`
@@ -62,7 +62,7 @@ type DashboardResponse struct {
 		ID           int           `json:"id"`
 		Links        []interface{} `json:"links"`
 		Panels       []struct {
-			Datasource  string `json:"datasource"`
+			Datasource  interface{} `json:"datasource"`
 			FieldConfig struct {
 				Defaults struct {
 					Custom struct {


### PR DESCRIPTION
The fix is changing Datasource string to Datasource interface{} — it makes the struct tolerant of both formats regardless of dashboard schema version(if in case the schema version is different) cause other clients works with Datasource string but Niger is facing this issue.